### PR TITLE
add GCP token file to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@
 /Dockerfile
 /tests
 /vendor
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
reference bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1959182