### PR TITLE
Add information on iOS weekly releases to the Milestone description

### DIFF
--- a/app/views/templates/future_release.html.twig
+++ b/app/views/templates/future_release.html.twig
@@ -263,7 +263,7 @@
             <br><small class="fw-normal">Desktop &amp; Android</small>
             <br><small class="fw-normal text-muted">
                 iOS branches every Friday and starts a phased rollout on Sunday after a week of stabilization.
-                Major iOS versions match Desktop (e.g., {{ release }}.0), followed by weekly dot releases ('{{ release }}.1, {{ release }}.2, {{ release }}.3) before the next major.
+                <br>Major iOS versions match Desktop (e.g., {{ release }}.0), followed by weekly dot releases ({{ release }}.1, {{ release }}.2, {{ release }}.3) before the next major.
             </small>
         </th>
 {% for key, value in cycle_dates %}


### PR DESCRIPTION
Removed iOS from the Desktop and Android text and added a line about iOS weekly releases 