### PR TITLE
Updates the 2026 iOS schedule for wellness days and extra releases

### DIFF
--- a/app/classes/ReleaseInsights/IOS.php
+++ b/app/classes/ReleaseInsights/IOS.php
@@ -98,7 +98,6 @@ class IOS extends Release
             $milestones += [
                 'merge_day_4'      => $date('2026-01-30'),
                 'rc_gtb_4'         => $date('+4 hours'),
-                'release_1'        => $date('Monday 02:00 UTC'),
                 'qa_pre_signoff_4' => $date('Monday 17:00 UTC'),
                 'qa_signoff_4'     => $date('Tuesday'),
                 'appstore_sent_4'  => $date('Thursday'),
@@ -118,6 +117,36 @@ class IOS extends Release
             $milestones['rc_gtb_3'] = '2026-03-05 00:04:00+00:00';
         }
 
+        if ($v == '152.0') {
+            // Wellness day on June 5
+            $milestones['merge_day_0'] = '2026-06-04 00:00:00+00:00';
+            $milestones['rc_gtb_0'] = '2026-06-04 00:04:00+00:00';
+        }
+
+        // Extra dot releases only for 152
+        if ($v === '152.0') {
+            $milestones += [
+                'merge_day_4'      => $date('2026-07-03'),
+                'rc_gtb_4'         => $date('+4 hours'),
+                'release_3'        => $date('Monday 02:00 UTC'),
+                'qa_pre_signoff_4' => $date('Monday 17:00 UTC'),
+                'qa_signoff_4'     => $date('Tuesday'),
+                'appstore_sent_4'  => $date('Thursday'),
+                'release_4'        => $date('Monday 02:00 UTC'),
+            ];
+        }
+
+        if ($v == '154.0') {
+            // Wellness day on August 28
+            $milestones['merge_day_3'] = '2026-08-27 00:00:00+00:00';
+            $milestones['rc_gtb_3'] = '2026-08-27 00:04:00+00:00';
+        }
+
+        if ($v == '156.0') {
+            // Wellness day on October 23
+            $milestones['merge_day_3'] = '2026-10-22 00:00:00+00:00';
+            $milestones['rc_gtb_3'] = '2026-10-22 00:04:00+00:00';
+        }
 
         return $this->normalize($milestones);
     }
@@ -149,6 +178,12 @@ class IOS extends Release
             $milestones += [
                 'dot_release_4' => (clone $ios_release)->modify('+28 days'),
                 'dot_release_5' => (clone $ios_release)->modify('+35 days'),
+            ];
+        }
+
+        if ($v === '152.0') {
+            $milestones += [
+                'dot_release_4' => (clone $ios_release)->modify('+28 days'),
             ];
         }
 

--- a/app/views/templates/future_release.html.twig
+++ b/app/views/templates/future_release.html.twig
@@ -301,6 +301,12 @@
     {% set ios_cycle_descriptions = ios_cycle_descriptions|merge({ merge_day_3:'The <code>firefox-v' ~ release ~ '.3</code> branch is created from the <code>main</code> branch. <code>version.txt</code> is bumped to ' ~ (release)  ~ '.4 on <code>main</code>. Any further code change for the ' ~ release ~ '.3 release now requires an uplift request.'}) %}
   {% endif %}
 
+  {% if release == '152' %}
+    {# We have one extra weekly iOS releases for the 147 cycle #}
+    {% set ios_cycle_descriptions = ios_cycle_descriptions|merge({ merge_day_3:'The <code>firefox-v' ~ release ~ '.3</code> branch is created from the <code>main</code> branch. <code>version.txt</code> is bumped to ' ~ (release)  ~ '.4 on <code>main</code>. Any further code change for the ' ~ release ~ '.3 release now requires an uplift request.'}) %}
+    {% set ios_cycle_descriptions = ios_cycle_descriptions|merge({ merge_day_4:'The <code>firefox-v' ~ release ~ '.3</code> branch is created from the <code>main</code> branch. <code>version.txt</code> is bumped to ' ~ (release+1)  ~ '.0 on <code>main</code>. Any further code change for the ' ~ release ~ '.3 release now requires an uplift request.'}) %}
+  {% endif %}
+
   {% set cycle_descriptions = {
     nightly_start: 'The first day of the cycle is <i>Merge Day</i>. After merging mozilla-central to mozilla-beta, we bump the nightly version number on mozilla-central and a new development cycle starts for Firefox. A new Firefox Nightly is shipped every 12 hours.',
     a11y_request_deadline: 'Accessibility engineering review has been requested (<a href="https://firefox-source-docs.mozilla.org/bug-mgmt/processes/accessibility-review.html#requesting-engineering-review">using the <code>a11y-review</code> flag on Bugzilla</a>) for new (or significantly redesigned) UI that requires assessment to determine whether it is accessible to people with disabilities.',

--- a/tests/Unit/ReleaseInsights/IOSTest.php
+++ b/tests/Unit/ReleaseInsights/IOSTest.php
@@ -27,6 +27,20 @@ test('IOS->getSchedule()', function () {
     $obj = new IOS('148.0'); // Wellness
     expect($obj->getSchedule()['merge_day_3'])->toBe('2026-03-05 00:00:00+00:00');
     expect($obj->getSchedule()['rc_gtb_3'])->toBe('2026-03-05 00:04:00+00:00');
+
+    $obj = new IOS('152.0'); // Wellness and an extra release
+    expect($obj->getSchedule()['merge_day_0'])->toBe('2026-06-04 00:00:00+00:00');
+    expect($obj->getSchedule()['rc_gtb_0'])->toBe('2026-06-04 00:04:00+00:00');
+    expect($obj->getSchedule())->toHaveKeys(['version', 'merge_day_0', 'rc_gtb_0', 'qa_pre_signoff_0', 'qa_signoff_0', 'appstore_sent_0', 'merge_day_1', 'rc_gtb_1', 'qa_pre_signoff_1', 'release_0', 'qa_signoff_1', 'appstore_sent_1', 'merge_day_2', 'rc_gtb_2', 'qa_pre_signoff_2', 'release_1', 'qa_signoff_2', 'appstore_sent_2', 'merge_day_3', 'rc_gtb_3', 'qa_pre_signoff_3', 'release_2', 'qa_signoff_3', 'appstore_sent_3', 'merge_day_4', 'rc_gtb_4', 'qa_pre_signoff_4', 'release_3', 'qa_signoff_4', 'appstore_sent_4', 'release_4',]);
+    expect($obj->getPastSchedule())->toHaveKeys(['dot_release_4',]);
+
+    $obj = new IOS('154.0'); // Wellness
+    expect($obj->getSchedule()['merge_day_3'])->toBe('2026-08-27 00:00:00+00:00');
+    expect($obj->getSchedule()['rc_gtb_3'])->toBe('2026-08-27 00:04:00+00:00');
+
+    $obj = new IOS('156.0'); // Wellness
+    expect($obj->getSchedule()['merge_day_3'])->toBe('2026-10-22 00:00:00+00:00');
+    expect($obj->getSchedule()['rc_gtb_3'])->toBe('2026-10-22 00:04:00+00:00');
 });
 
 


### PR DESCRIPTION
Move the iOS merge days that fall on a wellness day to one day earlier (152, 154, and 156)
Add an extra release to the iOS 152 cycle since iOS 153 has a longer beta