### PR TITLE
Move the ESR140 EOL to Fx158 on Oct 13

### DIFF
--- a/app/classes/ReleaseInsights/ESR.php
+++ b/app/classes/ReleaseInsights/ESR.php
@@ -77,14 +77,17 @@ class ESR
         ];
 
         /*
-            1. We support 2 ESR branches for 3 releases only since Version 68.
-            2. Before that, we had 2 cycles only with 2 ESR branches as cycles lasted longer
+            1. We support 2 ESR branches for 5 releases by default since we moved to a 2 week cadence from Firefox 155, this is what the next transition (from ESR 153) will use.
+            ESR 140 is an exception with 4 releases because Firefox 154 was still 4 weeks after 153 before the switch to 2 week cycles at 155, this keeps ESR 140 EOL on October 13 (Firefox 158).
+            2. Before that, we had 2 ESR branches for 3 releases only since Version 68 and before that we had 2 cycles only with 2 ESR branches as cycles lasted longer
             3. We extended the 115 ESR cycle because of a still large Windows 7/8.1 population
         */
         $esr_minor_releases = match(true) {
-                $version < 78        => 1,
-                $current_ESR === 128 => 11,
-                default              => 3,
+                $version < 78         => 1,
+                $current_ESR === 128  => 11,
+                $previous_ESR < 140   => 3,
+                $previous_ESR === 140 => 4,
+                default               => 5,
         };
 
         if (($version - $current_ESR) > $esr_minor_releases) {

--- a/app/views/templates/esr_release.html.twig
+++ b/app/views/templates/esr_release.html.twig
@@ -98,11 +98,9 @@
                 <small class="badge bg-warning text-dark">ESR 115 branch is EOL</small>
         {% endif %}
 
-        {% if
-            values.release|number_format > values.esr|number_format
-            and values.release|number_format - values.esr|number_format == 3
-        %}
-                <small class="badge bg-warning text-dark">ESR {{ esr_eol_tag }} branch is EOL</small>
+        {# The previous row still shipped the old ESR but this one no longer does: it is now EOL #}
+        {% if esr_eol_tag is defined and esr_eol_tag is not empty and values.old_esr is empty %}
+                <small class="badge bg-warning text-dark">ESR {{ esr_eol_tag|number_format }} branch is EOL</small>
         {% endif %}
 
         {{ values.date|format_date(pattern='MMMM d') }}
@@ -130,8 +128,8 @@
                 </tr>
             {% endif %}
         {% endfor %}
-        {#  We use a temp variable to store the EOL ESR version for the visual bubble #}
-        {% set esr_eol_tag =  values.old_esr|number_format %}
+        {#  We use a temp variable to store the previous row's old ESR (raw, so an empty value stays empty) #}
+        {% set esr_eol_tag = values.old_esr %}
     {% endfor %}
     </table>
 

--- a/tests/Unit/ReleaseInsights/ESRTest.php
+++ b/tests/Unit/ReleaseInsights/ESRTest.php
@@ -33,7 +33,13 @@ test('ESR::getOlderSupportedVersion', function ($input, $output) {
     [10, null],
     [102, '91.11.0'],
     [136, '115.21.0'],
+    // ESR 128 (retired in the 4-week cadence) is supported for 3 releases, until Firefox 143, then EOL.
+    [143, '128.15.0'],
+    [144, null],
     [155, '140.15.0'],
+    // ESR 140's last release is 140.17 (Firefox 157); it is EOL from Firefox 158 (2026-10-13).
+    [157, '140.17.0'],
+    [158, null],
     [1000, null],
 ]);
 


### PR DESCRIPTION
It was a bit tricky since the ESR140 eol pattern will not be the same as the ESR153 eol pattern. 154 releases 4 weeks after 153, and the 2-week cycle only kicks in from 155 onwards. 
When we get to ESR153 the default should just "work" and it won't need any exceptions.