### PR TITLE
Add esr and esr_previous to api/lando/uplift/train

### DIFF
--- a/app/classes/ReleaseInsights/API/LandoUpliftTrain.php
+++ b/app/classes/ReleaseInsights/API/LandoUpliftTrain.php
@@ -7,7 +7,6 @@ namespace ReleaseInsights\API;
 use DateTime;
 use ReleaseInsights\Beta;
 use ReleaseInsights\Data;
-use ReleaseInsights\ESR;
 use ReleaseInsights\Release;
 use ReleaseInsights\Version;
 
@@ -56,12 +55,6 @@ class LandoUpliftTrain
         $nightly = RELEASE + 2;
         $beta    = RELEASE + 1;
 
-        // Current ESR and the previous ESR branch (major versions).
-        // $esr_previous is null once the previous ESR reaches end-of-life.
-        $esr          = (int) Version::getMajor(ESR::getVersion(RELEASE));
-        $older_esr    = ESR::getOlderSupportedVersion(RELEASE);
-        $esr_previous = $older_esr !== null ? (int) Version::getMajor($older_esr) : null;
-
         /*
             We need specific logic for this API for the period of time when we are past RC,
             or have shipped to release, but not yet shipped our first beta. That is about 3 days,
@@ -105,9 +98,11 @@ class LandoUpliftTrain
                 'release_date' => $date(FIREFOX_RELEASE),
             ],
             'esr' => [
-                'version' => $esr,
+                'version' => NEXT_ESR ?: CURRENT_ESR,
             ],
-            'esr_previous' => $esr_previous !== null ? ['version' => $esr_previous] : null,
+            'esr_previous' => [
+                'version' => NEXT_ESR && CURRENT_ESR ? CURRENT_ESR : null,
+            ],
         ];
     }
 }

--- a/app/classes/ReleaseInsights/API/LandoUpliftTrain.php
+++ b/app/classes/ReleaseInsights/API/LandoUpliftTrain.php
@@ -7,7 +7,9 @@ namespace ReleaseInsights\API;
 use DateTime;
 use ReleaseInsights\Beta;
 use ReleaseInsights\Data;
+use ReleaseInsights\ESR;
 use ReleaseInsights\Release;
+use ReleaseInsights\Version;
 
 /*
     This is only consumed by our API endpoint /api/lando/uplift/train/
@@ -54,6 +56,12 @@ class LandoUpliftTrain
         $nightly = RELEASE + 2;
         $beta    = RELEASE + 1;
 
+        // Current ESR and the previous ESR branch (major versions).
+        // $esr_previous is null once the previous ESR reaches end-of-life.
+        $esr          = (int) Version::getMajor(ESR::getVersion(RELEASE));
+        $older_esr    = ESR::getOlderSupportedVersion(RELEASE);
+        $esr_previous = $older_esr !== null ? (int) Version::getMajor($older_esr) : null;
+
         /*
             We need specific logic for this API for the period of time when we are past RC,
             or have shipped to release, but not yet shipped our first beta. That is about 3 days,
@@ -96,6 +104,10 @@ class LandoUpliftTrain
                 'version'      => RELEASE,
                 'release_date' => $date(FIREFOX_RELEASE),
             ],
+            'esr' => [
+                'version' => $esr,
+            ],
+            'esr_previous' => $esr_previous !== null ? ['version' => $esr_previous] : null,
         ];
     }
 }

--- a/app/inc/config.php
+++ b/app/inc/config.php
@@ -45,11 +45,12 @@ define('FIREFOX_BETA',    $firefox_versions['LATEST_FIREFOX_RELEASED_DEVEL_VERSI
 define('FIREFOX_RELEASE', $firefox_versions['LATEST_FIREFOX_VERSION']);
 
 // Major version numbers (integers), used across the app
-define('NIGHTLY',  (int) FIREFOX_NIGHTLY);
-define('BETA',     (int) FIREFOX_BETA);
-define('RELEASE',  (int) FIREFOX_RELEASE);
-define('MAIN_ESR', (int) (ESR_NEXT != '' ? ESR_NEXT : ESR));
-define('OLD_ESR',  (int) (ESR115 != '' ? ESR115 : (ESR_NEXT != '' ? ESR : ESR_NEXT)));
+define('NIGHTLY',     (int) FIREFOX_NIGHTLY);
+define('BETA',        (int) FIREFOX_BETA);
+define('RELEASE',     (int) FIREFOX_RELEASE);
+define('NEXT_ESR',    (int) (ESR_NEXT ?: null));
+define('CURRENT_ESR', (int) ESR);
+define('WIN7_ESR',    ESR115 ? (int) ESR115 : null);
 
 // Are we on one of our staging sites
 $http_host = isset($_SERVER['HTTP_HOST']) ? (string) $_SERVER['HTTP_HOST'] : null;

--- a/app/views/templates/esr_release.html.twig
+++ b/app/views/templates/esr_release.html.twig
@@ -11,7 +11,7 @@
   {% if constant('ESR_NEXT') %}
     <h1 class="mx-auto w-50  mb-3 text-center">Firefox <abbr title="Extended Support Release ">ESR</abbr> {{ current_ESR|number_format }} & {{ next_ESR|number_format }}</h1>
   {% else %}
-    <h1 class="mx-auto w-50  mb-3 text-center">Firefox {{ constant('MAIN_ESR') }} <abbr title="Extended Support Release ">ESR</abbr></h1>
+    <h1 class="mx-auto w-50  mb-3 text-center">Firefox {{ constant('LATEST_ESR') }} <abbr title="Extended Support Release ">ESR</abbr></h1>
   {% endif %}
 
     <div class="w-50 alert alert-primary mx-auto text-center mb-3" role="alert">Version shipping to end-users on the <b>ESR</b> channel</div>
@@ -39,7 +39,7 @@
         </tr>
     {% endif %}
     </table>
-{% if constant('OLD_ESR')|number_format == 115 %}
+{% if constant('WIN7_ESR')|number_format == 115 %}
   {% set alert = alert ~ '
 
     <div class="w-100">

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -43,3 +43,9 @@ function something()
 {
     // ..
 }
+
+expect()->extend('toBeNullOrInt', function () {
+    expect(is_null($this->value) || is_int($this->value))->toBeTrue();
+
+    return $this; // Allows expectation chaining
+});

--- a/tests/Unit/ReleaseInsights/API/LandoUpliftTrainTest.php
+++ b/tests/Unit/ReleaseInsights/API/LandoUpliftTrainTest.php
@@ -8,8 +8,8 @@ test('LandoUpliftTrain->getTrains()', function () {
     // Root structure
     expect($obj->getTrains())
         ->toBeArray()
-        ->toHaveCount(3) // We have 3 root keys only
-        ->toHavekeys(['nightly', 'beta', 'release']); // Keys are immutable
+        ->toHaveCount(5) // 3 trains plus the two ESR keys
+        ->toHavekeys(['nightly', 'beta', 'release', 'esr', 'esr_previous']); // Keys are immutable
 
     // Train general structure
     expect($obj->getTrains()['nightly'])
@@ -48,4 +48,17 @@ test('LandoUpliftTrain->getTrains()', function () {
         ->toBeBool();
     expect($obj->getTrains()['beta']['is_rc_shipped'])
         ->toBeBool();
+
+    // ESR entries mirror the other trains; esr_previous is null once the previous ESR is EOL
+    expect($obj->getTrains()['esr'])
+        ->toHaveCount(1)
+        ->toHavekeys(['version']);
+    expect($obj->getTrains()['esr']['version'])
+        ->toBeInt();
+    if ($obj->getTrains()['esr_previous'] !== null) {
+        expect($obj->getTrains()['esr_previous'])
+            ->toHavekeys(['version']);
+        expect($obj->getTrains()['esr_previous']['version'])
+            ->toBeInt();
+    }
 });

--- a/tests/Unit/ReleaseInsights/API/LandoUpliftTrainTest.php
+++ b/tests/Unit/ReleaseInsights/API/LandoUpliftTrainTest.php
@@ -49,16 +49,15 @@ test('LandoUpliftTrain->getTrains()', function () {
     expect($obj->getTrains()['beta']['is_rc_shipped'])
         ->toBeBool();
 
-    // ESR entries mirror the other trains; esr_previous is null once the previous ESR is EOL
+    // ESR entries mirror the other trains; esr_previous.version is null once the previous ESR is EOL
     expect($obj->getTrains()['esr'])
         ->toHaveCount(1)
         ->toHavekeys(['version']);
     expect($obj->getTrains()['esr']['version'])
         ->toBeInt();
-    if ($obj->getTrains()['esr_previous'] !== null) {
-        expect($obj->getTrains()['esr_previous'])
-            ->toHavekeys(['version']);
-        expect($obj->getTrains()['esr_previous']['version'])
-            ->toBeInt();
-    }
+    expect($obj->getTrains()['esr_previous'])
+        ->toHaveCount(1)
+        ->toHavekeys(['version']);
+    expect($obj->getTrains()['esr_previous']['version'])
+        ->toBeNullOrInt();
 });

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -10,6 +10,8 @@ const FIREFOX_RELEASE  = '152.0';
 const FIREFOX_BETA     = '153.0b8';
 const FIREFOX_NIGHTLY  = '154.0a1';
 const ESR              = '140.12.0esr';
+const ESR_NEXT         = '';
+const ESR115           = '115.37.0esr';
 const INSTALL_ROOT     = __DIR__ . '/../';
 const CONTROLLERS      = INSTALL_ROOT . 'app/controllers/';
 const MODELS           = INSTALL_ROOT . 'app/models/';
@@ -21,9 +23,12 @@ const TESTING_CONTEXT  = true;
 const IS_DEV_MODE      = true;
 
 // Major version numbers (integers), used across the app
-define('NIGHTLY', (int) FIREFOX_NIGHTLY);
-define('BETA',    (int) FIREFOX_BETA);
-define('RELEASE', (int) FIREFOX_RELEASE);
+define('NIGHTLY',     (int) FIREFOX_NIGHTLY);
+define('BETA',        (int) FIREFOX_BETA);
+define('RELEASE',     (int) FIREFOX_RELEASE);
+define('NEXT_ESR',    (int) (ESR_NEXT ?: null));
+define('CURRENT_ESR', (int) ESR);
+define('WIN7_ESR',    ESR115 ? (int) ESR115 : null);
 
 // Are we on one of our staging sites
 define('LOCALHOST',  isset($_SERVER['SERVER_NAME']) && $_SERVER['SERVER_NAME'] === 'localhost');


### PR DESCRIPTION
I think it makes sense to use RELEASE here for the corresponding ESR versions